### PR TITLE
permalink definition for posts

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -28,6 +28,8 @@ url: "https://karakun.github.io" # the base hostname & protocol for your site, e
 twitter_username: karakun
 github_username:  karakun
 
+permalink: /:year/:month/:day/:title.html
+
 # Build settings
 markdown: kramdown
 plugins:

--- a/_posts/2018-06-25-java-releases.md
+++ b/_posts/2018-06-25-java-releases.md
@@ -6,6 +6,7 @@ featuredImage: tip-jar
 excerpt: 'This post gives an overview of the new Java release train as it was announced by Oracle. Plus, the article provides some important 
 information and hints how you should handle new Java releases in the future and helps you to decide if you need to buy commercial Java support 
 or not.'
+permalink: '/java/2018/06/25/java-releases.html'
 categories: [Java]
 header:
   text: Do I need to pay for <span class="my-karakun">Java<span> now?

--- a/_posts/2018-06-29-flavoured-artefacts-with-gradle.md
+++ b/_posts/2018-06-29-flavoured-artefacts-with-gradle.md
@@ -4,6 +4,7 @@ title:  'Flavoured artefacts from a multi-module build with Gradle'
 author: markus
 featuredImage: flavours-tom-hermans-642316-unsplash
 excerpt: 'Customized artefacts can be a headache to build and distribute. To the rescue, Gradle provides a powerful DSL that can solve that task easily - here is an example how.'
+permalink: '/java/gradle/build/2018/06/29/flavoured-artefacts-with-gradle.html'
 categories: [Java, Gradle, build]
 header:
   text: Flavoured artefacts with <span class="my-karakun">Gradle<span>

--- a/_posts/2018-09-16-java-11-licence.md
+++ b/_posts/2018-09-16-java-11-licence.md
@@ -4,6 +4,7 @@ title:  'The road to Java 11 - builds and licences'
 author: hendrik
 featuredImage: open-jdk
 excerpt: 'This post is the first of our Java 11 posts that will introduce all needed information about the next Java release. In this post you can find all needed information about the free and commercial versions of Java 11.'
+permalink: '/java/2018/09/16/java-11-licence.html'
 categories: [Java]
 header:
   text: The road to <span class="my-karakun">Java 11<span>

--- a/_posts/2018-09-16-jc-java-article.md
+++ b/_posts/2018-09-16-jc-java-article.md
@@ -6,6 +6,7 @@ featuredImage: labyrinth
 excerpt: 'Based on the confusion and rumors about the new Java release model a group of Java Champions has written
 an open article. The authors of the article worked together with mayor Java vendors to answer all questions
 about Java releases and licenses'
+permalink: '/java/2018/09/16/jc-java-article.html'
 categories: [Java]
 header:
   text: The road to <span class="my-karakun">Java 11<span>

--- a/_posts/2018-09-25-java11-release-event.md
+++ b/_posts/2018-09-25-java11-release-event.md
@@ -7,6 +7,7 @@ excerpt: 'Together with Oracle and Heise we will do a Java 11 release event.
 The event will be live streamed and recorded at YouTube. If you are interested in the
 new features of Java 11 and want to know more information about the new roadmap
 of OpenJDK and Oracle you should attend our event online.'
+permalink: '/java/2018/09/25/java11-release-event.html'
 categories: [Java]
 header:
   text: The road to <span class="my-karakun">Java 11<span>

--- a/_posts/2018-10-20-karakun-at-oracle-code-one.md
+++ b/_posts/2018-10-20-karakun-at-oracle-code-one.md
@@ -4,6 +4,7 @@ title:  'Karakun at Oracle Code One'
 author: hendrik
 featuredImage: oracle-code-one
 excerpt: 'This year Oracle does the first Code One conference in San Francisco. Code One is the successor of the famous JavaOne conference and will connect developers of different programming languages and backgrounds. Karakun will have several sessions and activities at Code One.'
+permalink: '/conferences/java/codeone/2018/10/20/karakun-at-oracle-code-one.html'
 categories: [Conferences, Java, CodeOne]
 header:
   text: Oracle Code One and Karakun

--- a/_posts/2018-11-01-multidevice-controls.md
+++ b/_posts/2018-11-01-multidevice-controls.md
@@ -4,6 +4,7 @@ title:  'Multidevice controls at Code One'
 author: hendrik
 featuredImage: multi-device
 excerpt: 'Everybody knows boring form-based user interfaces. What if you could add mobile devices to improve the UX of desktop or web applications? This Code One session a concept that was created by the University of Applied Sciences and Arts Northwestern Switzerland and Karakun for multi device controls.'
+permalink: '/conferences/java/codeone/javafx/swift/polymer/2018/11/01/multidevice-controls.html'
 categories: [Conferences, Java, CodeOne, JavaFX, Swift, Polymer]
 header:
   text: Multidevice controls at <span class="my-karakun">Code One<span>

--- a/_posts/2018-11-04-jfx-day.md
+++ b/_posts/2018-11-04-jfx-day.md
@@ -6,7 +6,8 @@ featuredImage: jfx-day
 excerpt: 'The first ever “JavaFX-Only” conference will take place from December 3rd to 5th, 2018. The ambitious schedule 
 of the JavaFX Days includes trainings, presentations, demos and a “Java on Mobile” day. The organiser of this 3 day event
 was able to recruit some of the best and most experienced JavaFX developers for the trainings and presentations. Karakun 
-is proud sponsor of this extraordinary event. '
+is proud sponsor of this extraordinary event.'
+permalink: '/conferences/javafx/2018/11/04/jfx-day.html'
 categories: [Conferences, JavaFX]
 header:
   image: post

--- a/_posts/2018-11-04-wjax-2018.md
+++ b/_posts/2018-11-04-wjax-2018.md
@@ -4,6 +4,7 @@ title:  'Karakun at W-JAX 2018'
 author: hendrik
 featuredImage: mic
 excerpt: 'The W-JAX conference takes place next week in Munich and we will do some sessions at the conference and organize some additional events in Munich. Even if you can not attend the conference we would love to invite you to a hackathon about React.'
+permalink: '/conferences/java/react/javascript/2018/11/04/wjax-2018.html'
 categories: [Conferences, Java, React, JavaScript]
 header:
   image: post

--- a/_posts/2018-11-08-react-training-announced.md
+++ b/_posts/2018-11-08-react-training-announced.md
@@ -4,6 +4,7 @@ title:  'Karakun React training in 2019'
 author: timo
 featuredImage: training-1
 excerpt: 'Beginning next year we will offer trainings to different topics in different locations. We are happy to announce that our first training is already able for booking. Our JavaScript expert Simon Skoczylas will host a training about React in Munich. Hurry up and book your seat soon!'
+permalink: '/javascript/react/2018/11/08/react-training-announced.html'
 categories: [JavaScript, React]
 header:
   image: training

--- a/_posts/2018-11-23-amazon-corretto.md
+++ b/_posts/2018-11-23-amazon-corretto.md
@@ -5,6 +5,7 @@ author: hendrik
 featuredImage: icecream
 excerpt: 'At the Devoxx conference 2 weeks ago, Amazon announced Corretto as a new player in the OpenJDK market. Next to companies like SAP, Oracle or Bellsoft, the cloud computing company now provides a custom OpenJDK build. On the website Amazon Corretto is described as 
 "No-cost, multiplatform, production-ready distribution of OpenJDK". In this post I will have a deeper look at Corretto and explain why Amazon did this move.'
+permalink: '/java/openjdk/2018/11/23/amazon-corretto.html'
 categories: [Java, OpenJDK]
 header:
   text: Amazon <span class="my-karakun">Corretto<span>

--- a/_posts/2019-01-03-events-01-2019.md
+++ b/_posts/2019-01-03-events-01-2019.md
@@ -4,6 +4,7 @@ title:  'Karakun events in January 2019'
 author: hendrik
 featuredImage: confetti
 excerpt: 'We will start the new year with some cool meetups and events. This post gives an overview about everything that is planed for January'
+permalink: '/java/2019/01/03/events-01-2019.html'
 categories: [Java]
 header:
   text: Karakun events in January

--- a/_posts/2019-01-09-integration-docker.md
+++ b/_posts/2019-01-09-integration-docker.md
@@ -5,6 +5,7 @@ author: hendrik
 featuredImage: whale
 excerpt: 'This post gives an overview how we at Karakun use Docker to create integration tests for 
 JavaEE / JakartaEE based libraries and frameworks.'
+permalink: '/java/docker/integration%20tests/tests/javaee/jakartaee/2019/01/09/integration-docker.html'
 categories: [Java, Docker, Integration Tests, Tests, JavaEE, JakartaEE]
 header:
   image: post

--- a/_posts/2019-01-15-rico-server-timing.md
+++ b/_posts/2019-01-15-rico-server-timing.md
@@ -4,6 +4,7 @@ title:  'Server Timing with Rico'
 author: hendrik
 featuredImage: clock
 excerpt: 'This post gives an overview about the new server timing specification of the w3c and how server timing can be used in any enterprise Java server by using Rico.'
+permalink: '/java/rico/2019/01/15/rico-server-timing.html'
 categories: [Java, Rico]
 header:
   text: Rico Server Timing

--- a/_posts/2019-01-25-security-exploits.md
+++ b/_posts/2019-01-25-security-exploits.md
@@ -7,6 +7,7 @@ excerpt: 'As developers we always try to create bug free and secure applications
 Sometimes the most critical issues are not part of our code but of its dependencies.
 This post shows how security issues in dependencies can be used to create horrible attack scenarios of your systems.
 I will show one exploit in a simply Java based server application that can be used to do mostly everything with your whole system.'
+permalink: '/java/openjdk/2019/01/25/security-exploits.html'
 categories: [Java, OpenJDK]
 header:
   text: An example of a small but evil <span class="my-karakun">exploit<span>


### PR DESCRIPTION
- All future posts will have a permalink that is defined like this: "/:year/:month/:day/:title.html"
- Based on the new permalink definition the categories are removed from the URL
- For all past posts a custom permalink is defined that matches the permalink as it was before this PR. By doing so external link won't break
