### PR TITLE
support for seo_title attribute on pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -39,6 +39,7 @@ kramdown:
   syntax_highlighter: rouge
   input: GFM
 plugins:
+  - jekyll-seo-tag
   - jekyll-feed
   - jekyll-paginate
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -9,7 +9,13 @@
     <meta property="og:image" content="{{ site.url }}/assets/images/raccoon.png" />
   {%- endif -%}
 
-  {%- seo -%}
+  {%- if page.seo_title -%}
+    <title>{{ page.seo_title }}</title>
+    {%- seo title=false -%}
+  {%- else -%}
+    {%- seo -%}
+  {%- endif -%}
+
   <link rel="stylesheet" href="{{ '/assets/main.css' | relative_url }}">
   <link rel="manifest" href="/manifest.json">
 


### PR DESCRIPTION
In case a page has the attribute "seo_title" set this will be used to generate the <head><title>seo_title</title></head>. If there is not seo_title set then the default title is used (i.e. "page_title | site_title")